### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const isObject = require('is-obj')
 
+const isPrototypePolluted = (property) => /__proto__|constructor|prototype/.test(property)
+
 module.exports = {
   get (obj, path, value) {
     if (!isObject(obj) || typeof path !== 'string') {
@@ -36,7 +38,7 @@ module.exports = {
         pointer[property] = propertyCount === index ? value : {}
       }
 
-      pointer = pointer[property]
+      pointer = isPrototypePolluted(property) ? {} : pointer[property]
     })
 
     return obj


### PR DESCRIPTION
### :bar_chart: Metadata *

`dot-prop-opt` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-dot-prop-opt

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const { set } = require('dot-prop-opt')

console.log(`Before: ${{}.polluted}`)
set({}, '__proto__.polluted', true)
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in terminal:
```bash
npm i dot-prop-opt # Install vulerable package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/105576395-7ab49800-5d98-11eb-8e35-96f65df8afdc.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
